### PR TITLE
Fixing a broken link in the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,6 @@ Example using shinytest with Travis CI
 
 [![Build Status](https://travis-ci.org/rstudio/shinytest-ci-example.svg?branch=master)](https://travis-ci.org/rstudio/shinytest-ci-example)
 
-This repository is an example to show how to use [shinytest](https://github.com/rstudio/shinytest) to test with Travis CI. For more information, see https://rstudio.github.io/shinytest/ci.html.
+This repository is an example to show how to use [shinytest](https://github.com/rstudio/shinytest) to test with Travis CI. For more information, see https://rstudio.github.io/shinytest/articles/ci.html.
 
 In this repository, there is a single application stored in the top level.


### PR DESCRIPTION
The link to the article on using shinytest with CI was broken - this commit fixes the link.

Closes #1 